### PR TITLE
Issue 9 add a settings link the link should point to the wp hardening security fixers page in the plugins list under wp hardening

### DIFF
--- a/wp-hardening.php
+++ b/wp-hardening.php
@@ -101,6 +101,15 @@ function whp_plugin_activation()
     }
 
 }
-
+/**
+* Add settings action link to the plugins page.
+*/
+add_filter( 'plugin_action_links_' . plugin_basename(__FILE__), 'add_action_links' );
+function add_action_links ( $links ) {
+    $settings_link = array(
+            '<a href="' . admin_url( 'admin.php?page=wphwp_harden_fixers') . '">' . __('Settings') . '</a>',
+    );
+   return array_merge( $links, $settings_link );
+}
 
 ?>


### PR DESCRIPTION
Closes #9 