### PR TITLE
Add defensive check when accessing a $_SERVER variable

### DIFF
--- a/modules/hooks.php
+++ b/modules/hooks.php
@@ -198,7 +198,7 @@ function whp_fixers_processing(){
 	if( $fixer_options['stop_user_enumeration'] == 'on' ){
 		if (!is_admin()) {
 			// default URL format
-			if (preg_match('/author=([0-9]*)/i', $_SERVER['QUERY_STRING'])){
+			if (isset($_SERVER['QUERY_STRING']) && preg_match('/author=([0-9]*)/i', $_SERVER['QUERY_STRING'])){
 			 	wp_redirect( get_option('home'), 302 ); exit;
 			}
 			add_filter('redirect_canonical', 'shapeSpace_check_enum', 10, 2);


### PR DESCRIPTION
See: https://github.com/getastra/wp-security-hardening/issues/49

When using WP Cli, the `QUERY_STRING` variable wasn't being set in the global `$_SERVER` config and the plugin was trying to access this without checking for its existence.

This MR adds a defensive check to only execute the code that relies on `QUERY_STRING` if it exists.